### PR TITLE
feat(component): add Preheader

### DIFF
--- a/src/components/Preheader/Preheader.tsx
+++ b/src/components/Preheader/Preheader.tsx
@@ -1,21 +1,30 @@
-interface PreheaderProps {
+import { makeStyles } from '../../utils/makeStyles';
+import { BaseStyleProp } from '../types';
+
+type PreheaderStyles = 'root';
+
+export interface PreheaderProps extends BaseStyleProp<PreheaderStyles> {
   text: string;
 }
 
-export const Preheader = ({ text }: PreheaderProps) => {
+const useStyles = makeStyles({
+  root: {
+    display: 'none',
+    fontSize: '1px',
+    color: '#fff',
+    lineHeight: '1px',
+    maxHeight: 0,
+    maxWidth: 0,
+    opacity: 0,
+    overflow: 'hidden',
+  },
+});
+
+export const Preheader = ({ text, classes, className }: PreheaderProps) => {
+  const styles = useStyles({ classes });
+
   return (
-    <div
-      style={{
-        display: 'none',
-        fontSize: '1px',
-        color: '#fff',
-        lineHeight: '1px',
-        maxHeight: 0,
-        maxWidth: 0,
-        opacity: 0,
-        overflow: 'hidden',
-      }}
-    >
+    <div style={styles.root} className={className}>
       {text}
     </div>
   );

--- a/src/components/Preheader/Preheader.tsx
+++ b/src/components/Preheader/Preheader.tsx
@@ -1,0 +1,22 @@
+interface PreheaderProps {
+  text: string;
+}
+
+export const Preheader = ({ text }: PreheaderProps) => {
+  return (
+    <div
+      style={{
+        display: 'none',
+        fontSize: '1px',
+        color: '#fff',
+        lineHeight: '1px',
+        maxHeight: 0,
+        maxWidth: 0,
+        opacity: 0,
+        overflow: 'hidden',
+      }}
+    >
+      {text}
+    </div>
+  );
+};

--- a/src/components/Preheader/index.ts
+++ b/src/components/Preheader/index.ts
@@ -1,0 +1,1 @@
+export { Preheader } from './Preheader';

--- a/src/components/Preheader/index.ts
+++ b/src/components/Preheader/index.ts
@@ -1,1 +1,1 @@
-export { Preheader } from './Preheader';
+export { Preheader, PreheaderProps } from './Preheader';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export * from './Link';
 export * from './Divider';
 export * from './Typography';
 export * from './Image';
+export * from './Preheader';


### PR DESCRIPTION
### This Pull Request covers:
- add a Preheader component with `text` prop to render preheader text on the email clients

### Reference:
[https://www.activecampaign.com/blog/email-preheader](https://www.activecampaign.com/blog/email-preheader)

Resolves #63

Signed-off-by: Niloy Sikdar <niloysikdar30@gmail.com>