### PR TITLE
build(config): change build config

### DIFF
--- a/fixup.sh
+++ b/fixup.sh
@@ -1,0 +1,13 @@
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/esm/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF
+
+echo "Fixup done."

--- a/package.json
+++ b/package.json
@@ -15,16 +15,27 @@
   },
   "homepage": "https://github.com/leopardslab/react-email#readme",
   "license": "Apache-2.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/esm/index.d.ts"
+    }
+  },
   "scripts": {
     "prepare": "husky install",
-    "build": "tsc -p tsconfig.json",
+    "build": "rm -rf dist && yarn build:esm && yarn build:cjs && yarn fixup",
+    "build:esm": "tsc -p tsconfig.json",
+    "build:cjs": "tsc -p tsconfig.json --module commonjs --outDir dist/cjs --target es2015",
+    "fixup": "chmod u+rx ./fixup.sh && ./fixup.sh",
     "watch": "tsc --watch",
-    "test": "jest",
+    "test": "jest --testPathPattern=src",
     "cm": "cz -s",
     "lint": "eslint src/**",
     "lint:fix": "eslint --fix src/**",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,12 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-    "outDir": "./dist/",
+    "baseUrl": "src",
+    "rootDir": "src",
+    "outDir": "./dist/esm",
     "lib": ["ESNext", "DOM"],
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "pretty": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
### The PR covers:

- Change tsc build config to generate both cjs and ESM versions

- Add package.json exports config to target ESM and cjs

- The last step of the build is a simple `fixup script` that creates per-distribution package.json files. These package.json files define the default package type for the .dist/* sub-directories

- Our package.json does not have a type property. Rather, we push that down to the package.json files under the ./dist/* sub-directories. We define an `exports` map which defines the entry points for the package: one for ESM and one for CJS.


Resolves #66

Signed-off-by: Niloy Sikdar <niloysikdar30@gmail.com>