### PR TITLE
feat(jsdoc): add JSDoc comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "lint-staged": "lint-staged",
     "release": "semantic-release --branches main",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook -o docs-build"
+    "build:storybook": "build-storybook -o storybook",
+    "build:typedoc": "typedoc"
   },
   "lint-staged": {
     "src/**": [
@@ -93,6 +94,7 @@
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "semantic-release": "^19.0.3",
+    "typedoc": "^0.23.10",
     "typescript": "^4.7.3"
   },
   "husky": {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,10 +5,28 @@ import { sx } from '../../utils/sx';
 
 type ButtonStyles = 'root' | 'primary' | 'secondary';
 
+/**
+ * Interface for PropTypes for the `Button` component.
+ */
 export interface ButtonProps extends BaseStyleProp<ButtonStyles> {
+  /**
+   * The content of the component.
+   */
   children?: ReactNode;
+  /**
+   * Applies the theme button styles.
+   * @default 'primary'
+   */
   variant?: 'primary' | 'secondary';
+  /**
+   * The URL to link to when the button is clicked.
+   * An `a` element will be used as the root node.
+   */
   href: string;
+  /**
+   * The target of the link.
+   * @default '_blank'
+   */
   target?: HTMLAttributeAnchorTarget;
 }
 

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -5,9 +5,23 @@ import { BaseStyleProp } from '../types';
 
 type ColumnStyles = 'root';
 
+/**
+ * Interface for PropTypes for the `Column` component.
+ */
 export interface ColumnProps extends BaseStyleProp<ColumnStyles> {
+  /**
+   * The content of the component.
+   */
   children?: ReactNode;
+  /**
+   * The alignment of the children.
+   * @default 'center'
+   */
   align?: 'left' | 'center' | 'right';
+  /**
+   * The vertical alignment of the children.
+   * @default 'top'
+   */
   verticalAlign?: CSSProperties['verticalAlign'];
 }
 

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -5,11 +5,33 @@ import { BaseStyleProp } from '../types';
 
 type DividerStyles = 'root';
 
+/**
+ * Interface for PropTypes for the `Divider` component.
+ */
 export interface DividerProps extends BaseStyleProp<DividerStyles> {
+  /**
+   * The alignment of the divider.
+   * @default 'left'
+   */
   align?: 'left' | 'center' | 'right';
+  /**
+   * The color of the divider.
+   */
   color?: CSSProperties['borderColor'];
+  /**
+   * The type of the divider.
+   * @default 'solid'
+   */
   type?: CSSProperties['borderStyle'];
+  /**
+   * The thickness of the divider.
+   * @default '1px'
+   */
   size?: CSSProperties['borderWidth'];
+  /**
+   * The width of the divider.
+   * @default '100%'
+   */
   width?: CSSProperties['width'];
 }
 

--- a/src/components/Email/Email.tsx
+++ b/src/components/Email/Email.tsx
@@ -4,7 +4,13 @@ import { makeStyles } from '../../utils/makeStyles';
 
 type EmailStyles = 'root';
 
+/**
+ * Interface for PropTypes for the `Email` component.
+ */
 export interface EmailProps extends BaseStyleProp<EmailStyles> {
+  /**
+   * The content of the component.
+   */
   children?: ReactNode;
 }
 

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -13,12 +13,35 @@ type ImageStyles =
   | 'captionSection'
   | 'imageColumn';
 
+/**
+ * Interface for PropTypes for the `Image` component.
+ */
 export interface ImageProps extends BaseStyleProp<ImageStyles> {
+  /**
+   * The URL or filepath of the image.
+   */
   src: string;
+  /**
+   * The alt text for the image.
+   */
   alt: string;
+  /**
+   * The caption for the image.
+   */
   caption?: string;
+  /**
+   * The width of the image.
+   */
   width: CSSProperties['width'];
+  /**
+   * The height of the image.
+   * @default 'auto'
+   */
   height?: CSSProperties['height'];
+  /**
+   * The alignment of the caption.
+   * @default 'center'
+   */
   captionAlign?: 'left' | 'center' | 'right';
 }
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -4,9 +4,22 @@ import { makeStyles } from '../../utils/makeStyles';
 
 type LinkStyles = 'root';
 
+/**
+ * Interface for PropTypes for the `Link` component.
+ */
 export interface LinkProps extends BaseStyleProp<LinkStyles> {
+  /**
+   * The content of the component.
+   */
   children?: ReactNode;
+  /**
+   * The URL to link to.
+   */
   href: string;
+  /**
+   * The target of the link.
+   * @default '_blank'
+   */
   target?: HTMLAttributeAnchorTarget;
 }
 

--- a/src/components/Preheader/Preheader.tsx
+++ b/src/components/Preheader/Preheader.tsx
@@ -3,7 +3,13 @@ import { BaseStyleProp } from '../types';
 
 type PreheaderStyles = 'root';
 
+/**
+ * Interface for PropTypes for the `Preheader` component.
+ */
 export interface PreheaderProps extends BaseStyleProp<PreheaderStyles> {
+  /**
+   * The text for the preheader.
+   */
   text: string;
 }
 

--- a/src/components/Quote/Quote.stories.tsx
+++ b/src/components/Quote/Quote.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Quote } from './Quote';

--- a/src/components/Quote/Quote.tsx
+++ b/src/components/Quote/Quote.tsx
@@ -4,7 +4,13 @@ import { BaseStyleProp } from '../types';
 
 type QuoteStyles = 'root';
 
+/**
+ * Interface for PropTypes for the `Quote` component.
+ */
 export interface QuoteProps extends BaseStyleProp<QuoteStyles> {
+  /**
+   * The content of the component.
+   */
   children?: ReactNode;
 }
 

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -5,8 +5,18 @@ import { BaseStyleProp } from '../types';
 
 type SectionStyles = 'root' | 'body' | 'row';
 
+/**
+ * Interface for PropTypes for the `Section` component.
+ */
 export interface SectionProps extends BaseStyleProp<SectionStyles> {
+  /**
+   * The content of the component.
+   */
   children?: ReactNode;
+  /**
+   * If `true`, the `section` will take up the full width of its container.
+   * @default true
+   */
   fullWidth?: boolean;
 }
 

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -5,8 +5,18 @@ import { sx } from '../../utils/sx';
 
 type ButtonStyles = 'root';
 
+/**
+ * Interface for PropTypes for the `Typography` component.
+ */
 export interface TypographyProps extends BaseStyleProp<ButtonStyles> {
+  /**
+   * The content of the component.
+   */
   children: ReactNode;
+  /**
+   * Applies the theme typography styles.
+   * @default 'body1'
+   */
   variant?:
     | 'h1'
     | 'h2'
@@ -19,6 +29,10 @@ export interface TypographyProps extends BaseStyleProp<ButtonStyles> {
     | 'body1'
     | 'body2'
     | 'caption';
+  /**
+   * Set the text-align on the component.
+   * @default 'left'
+   */
   align?: CSSProperties['textAlign'];
 }
 

--- a/src/components/types/index.ts
+++ b/src/components/types/index.ts
@@ -2,7 +2,7 @@ import { CSSProperties } from 'react';
 
 export interface BaseStyleProp<T extends string> {
   /**
-   * The classes object to be merged with the base styles.
+   * Override or extend the styles applied to the component.
    */
   classes?: Partial<Record<T, CSSProperties>>;
   /**

--- a/src/components/types/index.ts
+++ b/src/components/types/index.ts
@@ -1,6 +1,12 @@
 import { CSSProperties } from 'react';
 
 export interface BaseStyleProp<T extends string> {
+  /**
+   * The classes object to be merged with the base styles.
+   */
   classes?: Partial<Record<T, CSSProperties>>;
+  /**
+   * The class name to be applied to the element.
+   */
   className?: string;
 }

--- a/src/utils/generateEmail/generateEmail.ts
+++ b/src/utils/generateEmail/generateEmail.ts
@@ -2,12 +2,39 @@ import ReactDOMServer from 'react-dom/server';
 import fs from 'fs';
 import { deafultHTML } from './defaultHTML';
 
+/** An optional configuration object for `generateEmail` */
 interface GenerateEmailOptions {
+  /** HTML file path to override the base HTML. */
   baseTemplate?: string;
+  /** CSS file path to override the base CSS styles. */
   baseStyles?: string;
+  /**
+   * Placeholder text to replace the base CSS styles.
+   * @default 'EMAIL_BASE_STYLES'
+   */
   baseStylesReplacementString?: string;
+  /**
+   * Placeholder text to replace the email body.
+   * @default 'EMAIL_BODY_CONTENT'
+   */
   baseBodyReplacementString?: string;
 }
+
+/**
+ * Function to convert React Email Layouts to HTML.
+ * @param {React.ReactElement}  jsxElement - React email layout which needs to be converted.
+ * @param {Object} [options] - An optional param options for the additional configurations.
+ * @param {string} [options.baseTemplate] - HTML file path to override the base HTML.
+ * @param {string} [options.baseStyles] - CSS file path to override the base CSS styles.
+ * @param {string} [options.baseStylesReplacementString='EMAIL_BASE_STYLES'] - Placeholder text to replace the base CSS styles.
+ * @param {string} [options.baseBodyReplacementString='EMAIL_BODY_CONTENT'] - Placeholder text to replace the email body.
+ * @returns {string} HTML version of the email in string format.
+ * @example
+ * import { generateEmail } from '@leopardslab/react-email';
+ * import { EmailLayout } from './EmailLayout';
+ * const html = generateEmail(EmailLayout());
+ * console.log(html);
+ */
 
 export const generateEmail = (
   jsxElement: React.ReactElement,

--- a/src/utils/generateTextEmail/generateTextEmail.ts
+++ b/src/utils/generateTextEmail/generateTextEmail.ts
@@ -1,6 +1,17 @@
 import { generateEmail } from '../generateEmail';
 import { generateTextEmailFromHTML } from '../generateTextEmailFromHTML';
 
+/**
+ * Function to convert React Email Layouts to Text version.
+ * @param {JSX.Element}  jsxElement - React email layout which needs to be converted.
+ * @returns {string} Text version of the email in string format.
+ * @example
+ * import { generateTextEmail } from '@leopardslab/react-email';
+ * import { EmailLayout } from './EmailLayout';
+ * const text = generateTextEmail(EmailLayout());
+ * console.log(text);
+ */
+
 export const generateTextEmail = (jsxElement: JSX.Element): string => {
   const HTML = generateEmail(jsxElement);
   const plainText = generateTextEmailFromHTML(HTML);

--- a/src/utils/generateTextEmailFromHTML/generateTextEmailFromHTML.ts
+++ b/src/utils/generateTextEmailFromHTML/generateTextEmailFromHTML.ts
@@ -1,5 +1,11 @@
 import htmlToPlainText from 'textversionjs';
 
+/**
+ * Function to convert HTML Email to Text version.
+ * @param {string}  html - HTML which needs to be converted.
+ * @returns {string} Text version of the email in string format.
+ */
+
 export const generateTextEmailFromHTML = (html: string): string => {
   const plainText = htmlToPlainText(html, { headingStyle: 'hashify' });
   return plainText;

--- a/src/utils/makeStyles/makeStyles.ts
+++ b/src/utils/makeStyles/makeStyles.ts
@@ -19,6 +19,12 @@ const mergeStyles = (originalClasses: CSSClasses, overrideClasses: CSSClasses): 
   return newClasses;
 };
 
+/**
+ * Function which revokes a hook to combine and merge classes.
+ * @param classes - The classes to be merged with the override classes
+ * @returns The `useStyles` hook to combine and merge classes.
+ */
+
 export const makeStyles = (classes: CSSClasses) => {
   return (options?: overrideOptions) => {
     const overrideClasses = options?.classes;

--- a/src/utils/sx/sx.ts
+++ b/src/utils/sx/sx.ts
@@ -2,6 +2,12 @@ import { CSSProperties } from 'react';
 
 type SXProps = CSSProperties | false | undefined;
 
+/**
+ * Function to merge CSSProperties.
+ * @param args - The CSSProperties to be merged with the override CSSProperties
+ * @returns The merged CSSProperties.
+ */
+
 export const sx = (...args: SXProps[]): CSSProperties => {
   const initialValue: CSSProperties = {};
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,10 @@
     "jsx": "react-jsx",
     "pretty": true
   },
+  "typedocOptions": {
+    "entryPoints": ["./src/"],
+    "out": "typedoc"
+  },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9778,6 +9778,11 @@ json5@^2.1.2, json5@^2.1.3, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
+jsonc-parser@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.1.0.tgz#73b8f0e5c940b83d03476bc2e51a20ef0932615d"
+  integrity sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -10232,6 +10237,11 @@ lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.10.1.tgz#db577f42a94c168f676b638d15da8fb073448cab"
   integrity sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -10356,6 +10366,11 @@ marked@^4.0.10:
   version "4.0.17"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.17.tgz#1186193d85bb7882159cdcfc57d1dfccaffb3fe9"
   integrity sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==
+
+marked@^4.0.18:
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.18.tgz#cd0ac54b2e5610cfb90e8fd46ccaa8292c9ed569"
+  integrity sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -10608,7 +10623,7 @@ minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
+minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
@@ -13213,6 +13228,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shiki@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
+  integrity sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==
+  dependencies:
+    jsonc-parser "^3.0.0"
+    vscode-oniguruma "^1.6.1"
+    vscode-textmate "5.2.0"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -14223,6 +14247,16 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
+typedoc@^0.23.10:
+  version "0.23.10"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.10.tgz#285d595a5f2e35ccdf6f38eba4dfe951d5bff461"
+  integrity sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==
+  dependencies:
+    lunr "^2.3.9"
+    marked "^4.0.18"
+    minimatch "^5.1.0"
+    shiki "^0.10.1"
+
 typescript@^4.6.4, typescript@^4.7.3:
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
@@ -14572,6 +14606,16 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vscode-oniguruma@^1.6.1:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz#aeb9771a2f1dbfc9083c8a7fdd9cccaa3f386607"
+  integrity sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==
+
+vscode-textmate@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
+  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
 walk-up-path@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### This Pull Request covers:

- Proper JSDoc comments for all of our components and utility methods
- Add [TypeDoc](https://typedoc.org) to generate static doc site out of the comments

### References:

1. [https://jsdoc.app/about-getting-started.html](https://jsdoc.app/about-getting-started.html)
2. [https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html)

### TypeDoc site:

<img src="https://user-images.githubusercontent.com/58071992/184528709-e2bfea8a-32a1-4778-9eb0-77ffc4945074.png" width="600px" />

<img src="https://user-images.githubusercontent.com/58071992/184528707-2ca8e7b6-de9a-47d5-8961-ceb15db7e632.png" width="600px" />

<img src="https://user-images.githubusercontent.com/58071992/184528708-c7ff89d0-0102-4a19-a075-9180a12794db.png" width="600px" />




Resolves #61 

Signed-off-by: Niloy Sikdar <niloysikdar30@gmail.com>


