### PR TITLE
ci(releaserc): change releaseRules to trigger patch release for docs change with README scope

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,18 @@
     "main"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          {
+            "type": "docs",
+            "scope": "README",
+            "release": "patch"
+          }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",


### PR DESCRIPTION
### This Pull Request covers:

- Change `releaseRules` for `@semantic-release/commit-analyzer` and trigger patch release for `docs` change
with `README` scope

Resolves #77

Signed-off-by: Niloy Sikdar <niloysikdar30@gmail.com>