### PR TITLE
fix(exports): add missing exports

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,3 +8,4 @@ export * from './Typography';
 export * from './Image';
 export * from './Preheader';
 export * from './Quote';
+export type { ThemeOptions } from './DefaultTheme';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { sx } from './sx';
 export { makeStyles } from './makeStyles';
+export type { CSSClasses } from './makeStyles';
 export { generateEmail } from './generateEmail';
 export { generateTextEmailFromHTML } from './generateTextEmailFromHTML';
 export { generateTextEmail } from './generateTextEmail';

--- a/src/utils/makeStyles/index.ts
+++ b/src/utils/makeStyles/index.ts
@@ -1,1 +1,2 @@
 export { makeStyles } from './makeStyles';
+export type { CSSClasses } from './makeStyles';


### PR DESCRIPTION
### This Pull Request covers:

Add missing interface exports for CSSClasses and ThemeOptions from the package

Fixes #110

Signed-off-by: Niloy Sikdar <niloysikdar30@gmail.com>