### PR TITLE
ci(lint-staged): fix husky and lint-staged issues

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+if [ -t 2 ]; then
+  exec >/dev/tty 2>&1
+fi
+
 yarn test
-yarn lint-staged && git add -A .
+yarn lint-staged


### PR DESCRIPTION
Fix the excess amount of the same logs, which blows up the terminal/cmd on windows while running lint-staged from husky

![screenshot](https://user-images.githubusercontent.com/58071992/196017008-b51e2ccf-98d2-4b31-b735-d403e3bc5ad9.PNG)


Fixes #123

Signed-off-by: Niloy Sikdar <niloysikdar30@gmail.com>